### PR TITLE
Fixed swapping stacks of the same item if the end stack is at max stack size

### DIFF
--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -208,8 +208,10 @@ impl Inventory {
                         ),
                     );
                 } else {
-                    other_inventory.replace_slot_item_stack(end_slot, start_slot_itemstack);
-                    self.replace_slot_item_stack(start_slot, end_slot_itemstack);
+                    if end_slot_itemstack.amount as usize != end_max_stack_amount {
+                        other_inventory.replace_slot_item_stack(end_slot, start_slot_itemstack);
+                        self.replace_slot_item_stack(start_slot, end_slot_itemstack);
+                    }
                 }
             }
         }
@@ -366,7 +368,9 @@ impl Inventory {
                         ),
                     );
                 } else {
-                    self.swap_slots(start_slot, end_slot);
+                    if end_slot_itemstack.amount as usize != end_max_stack_amount {
+                        self.swap_slots(start_slot, end_slot);
+                    }
                 }
             }
         }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -208,7 +208,9 @@ impl Inventory {
                         ),
                     );
                 } else {
-                    if end_slot_itemstack.amount as usize != end_max_stack_amount {
+                    if end_slot_itemstack.amount as usize != end_max_stack_amount
+                    && end_slot_itemstack.item_type == ItemType::Air
+                    {
                         other_inventory.replace_slot_item_stack(end_slot, start_slot_itemstack);
                         self.replace_slot_item_stack(start_slot, end_slot_itemstack);
                     }
@@ -368,7 +370,9 @@ impl Inventory {
                         ),
                     );
                 } else {
-                    if end_slot_itemstack.amount as usize != end_max_stack_amount {
+                    if end_slot_itemstack.amount as usize != end_max_stack_amount 
+                    && end_slot_itemstack.item_type == ItemType::Air
+                    {
                         self.swap_slots(start_slot, end_slot);
                     }
                 }

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -209,7 +209,7 @@ impl Inventory {
                     );
                 } else {
                     if end_slot_itemstack.amount as usize != end_max_stack_amount
-                    && end_slot_itemstack.item_type == ItemType::Air
+                    || end_slot_itemstack.item_type == ItemType::Air
                     {
                         other_inventory.replace_slot_item_stack(end_slot, start_slot_itemstack);
                         self.replace_slot_item_stack(start_slot, end_slot_itemstack);
@@ -371,7 +371,7 @@ impl Inventory {
                     );
                 } else {
                     if end_slot_itemstack.amount as usize != end_max_stack_amount 
-                    && end_slot_itemstack.item_type == ItemType::Air
+                    || end_slot_itemstack.item_type == ItemType::Air
                     {
                         self.swap_slots(start_slot, end_slot);
                     }


### PR DESCRIPTION
All I added is an if statement to the item swapping code, preventing it from swapping if the end stack is already at max.
I tested this on my N0120 and it works fine (I did encounter trial and error but I got it working in the end).

Also yes, I did make sure to include this fix in both the in same inventory item swapping and different inventory item swapping.